### PR TITLE
Render formula output as html

### DIFF
--- a/src/kanban-view.ts
+++ b/src/kanban-view.ts
@@ -20,6 +20,7 @@ import {
 	TagValue,
 	TFile,
 	ViewOption,
+	parsePropertyId,
 } from 'obsidian';
 import type BasesKanbanPlugin from './main';
 import { DragDropManager } from './drag-drop';
@@ -260,7 +261,13 @@ export class KanbanView extends BasesView {
 		
 		// Value
 		const valueEl = rowEl.createSpan({ cls: 'bases-kanban-property-value' });
-		valueEl.setText(this.formatValue(value));
+		const { type } = parsePropertyId(propId);
+		// use renderTo for formula values to get dynamic rendering
+		if (type === "formula") {
+			value.renderTo(valueEl, this.app.renderContext);
+		} else {
+			valueEl.setText(this.formatValue(value));
+		}
 	}
 
 	private getIconForValue(value: Value, propId: BasesPropertyId): string {
@@ -291,6 +298,8 @@ export class KanbanView extends BasesView {
 					return 'file';
 			}
 		}
+
+		if (propId.startsWith('formula.')) return 'square-function';
 
 		// Check value type
 		if (value instanceof DateValue) return 'calendar';


### PR DESCRIPTION
This PR resolves #5: it renders the output of formula in Kanban cards as HTML instead of plain text.

It also changes the icon displayed next to the property in the card to `square-function` for all formula properties.