### PR TITLE
Support empty kanban columns

### DIFF
--- a/src/kanban-view.ts
+++ b/src/kanban-view.ts
@@ -95,8 +95,9 @@ export class KanbanView extends BasesView {
 		// Detect the groupBy property from the data (uses Bases groupBy configuration)
 		this.groupByProperty = this.detectGroupByProperty(groupedData);
 
-		// Sort groups by saved column order
-		const sortedGroups = this.sortGroupsByColumnOrder(groupedData);
+		// Include empty columns saved in column order, then sort by saved order
+		const groupsWithEmptyColumns = this.mergeWithEmptyColumnsFromOrder(groupedData);
+		const sortedGroups = this.sortGroupsByColumnOrder(groupsWithEmptyColumns);
 		this.currentGroups = sortedGroups;
 
 		// Render the kanban board
@@ -362,8 +363,14 @@ export class KanbanView extends BasesView {
 		}
 
 		const modal = new AddColumnModal(this.app, this.data?.data ?? [], (columnValue, selectedFiles) => {
-			if (!columnValue || selectedFiles.length === 0) return;
-			void this.addColumnToFiles(groupByProperty, columnValue, selectedFiles);
+			if (!columnValue) return;
+
+			this.ensureColumnInOrder(columnValue);
+			this.render();
+
+			if (selectedFiles.length > 0) {
+				void this.addColumnToFiles(groupByProperty, columnValue, selectedFiles);
+			}
 		});
 		modal.open();
 	}
@@ -605,6 +612,49 @@ export class KanbanView extends BasesView {
 	}
 
 	/**
+	 * Ensure a column name exists in persisted column order.
+	 */
+	private ensureColumnInOrder(columnName: string): void {
+		if (!columnName || columnName === NO_VALUE_COLUMN) {
+			return;
+		}
+
+		const columnOrder = this.getColumnOrderFromConfig();
+		if (columnOrder.includes(columnName)) {
+			return;
+		}
+
+		this.updateColumnOrder([...columnOrder, columnName]);
+	}
+
+	/**
+	 * Add synthetic empty groups for columns that exist in saved order but have no cards.
+	 */
+	private mergeWithEmptyColumnsFromOrder(groups: BasesEntryGroup[]): BasesEntryGroup[] {
+		const columnOrder = this.getColumnOrderFromConfig();
+		if (columnOrder.length === 0) {
+			return groups;
+		}
+
+		const existingNames = new Set(groups.map(group => this.getColumnName(group.key)));
+		const emptyGroups: BasesEntryGroup[] = [];
+
+		for (const columnName of columnOrder) {
+			if (!columnName || columnName === NO_VALUE_COLUMN || existingNames.has(columnName)) {
+				continue;
+			}
+
+			emptyGroups.push({
+				key: { toString: () => columnName } as Value,
+				entries: [],
+				hasKey: () => true,
+			} as BasesEntryGroup);
+		}
+
+		return [...groups, ...emptyGroups];
+	}
+
+	/**
 	 * Sort groups based on saved column order
 	 */
 	private sortGroupsByColumnOrder(groups: BasesEntryGroup[]): BasesEntryGroup[] {
@@ -786,17 +836,15 @@ class AddColumnModal extends Modal {
 			.addButton(btn => btn
 				.setButtonText('Create column')
 				.setCta()
-				.onClick(() => {
-					const value = this.columnValueInput.value.trim();
-					if (value && this.selectedFiles.size > 0) {
-						this.onSubmit(value, Array.from(this.selectedFiles));
-						this.close();
-					} else if (!value) {
-						new Notice('Please enter a column name');
-					} else {
-						new Notice('Please select at least one file');
-					}
-				}))
+					.onClick(() => {
+						const value = this.columnValueInput.value.trim();
+						if (value) {
+							this.onSubmit(value, Array.from(this.selectedFiles));
+							this.close();
+						} else if (!value) {
+							new Notice('Please enter a column name');
+						}
+					}))
 			.addButton(btn => btn
 				.setButtonText('Cancel')
 				.onClick(() => this.close()));


### PR DESCRIPTION
## Summary
- render columns from saved column order even when they have no cards
- allow creating a column without selecting any files
- persist new empty columns in column order immediately

<img width="2452" height="1170" alt="CleanShot 2026-02-25 at 15 17 28@2x" src="https://github.com/user-attachments/assets/82ff21d6-8790-4bcf-ba2d-acbcf9ca3e97" />


## Why
Currently a column only appears when at least one ticket/card exists in that group. This change supports predefined workflows with temporarily empty statuses.

## Testing
- npm run build
- verified locally in Obsidian with demo columns `ready`, `in_progress`, `blocked`, `done`
- confirmed empty `blocked` column renders (counts: `1, 1, 0, 1`)

## Related
- https://github.com/ewerx/obsidian-bases-kanban/issues/3
- https://github.com/ewerx/obsidian-bases-kanban/issues/2