### PR TITLE
feat: render http(s) URL property values as clickable links

### DIFF
--- a/src/kanban-view.ts
+++ b/src/kanban-view.ts
@@ -260,7 +260,31 @@ export class KanbanView extends BasesView {
 		
 		// Value
 		const valueEl = rowEl.createSpan({ cls: 'bases-kanban-property-value' });
-		valueEl.setText(this.formatValue(value));
+		const text = this.formatValue(value);
+		const urlMatch = text.match(/^https?:\/\/\S+$/);
+		if (urlMatch) {
+			const a = valueEl.createEl('a', {
+				href: text,
+				text: this.shortenUrl(text),
+				cls: 'external-link',
+			});
+			a.setAttr('target', '_blank');
+			a.setAttr('rel', 'noopener');
+			a.addEventListener('click', (evt) => evt.stopPropagation());
+		} else {
+			valueEl.setText(text);
+		}
+	}
+
+	private shortenUrl(url: string): string {
+		try {
+			const u = new URL(url);
+			const segments = u.pathname.split('/').filter(Boolean);
+			const last = segments[segments.length - 1];
+			return last ? `${u.hostname}/${last}` : u.hostname;
+		} catch {
+			return url;
+		}
 	}
 
 	private getIconForValue(value: Value, propId: BasesPropertyId): string {


### PR DESCRIPTION
## Summary

Property values that are external URLs currently render as plain text (`valueEl.setText(...)` in `renderPropertyRow`). This makes URL properties on cards clickable.

- Any property value matching `^https?://\S+$` is rendered as an `<a>` (with `target=_blank`, `rel=noopener`) instead of plain text.
- The label is shortened to `host/last-path-segment` so long URLs don't blow out the card width; non-URL values are unchanged.
- `click` propagation is stopped on the anchor so clicking a link doesn't initiate a card drag.

### Motivation

I'm using this plugin with a Bases task board where each card carries Jira and GitHub URL properties (via formulas). They were unclickable, which defeated the purpose of having them on the card. This is a generic fix — it applies to any URL-valued property, not just my use case.

## Test plan

- [ ] Card with a property whose value is an `https://` URL renders a clickable link that opens in the browser
- [ ] Clicking the link does **not** start a card drag
- [ ] Non-URL property values still render as before
- [ ] `npm run build` and `eslint ./src/` pass